### PR TITLE
service converts word_id to id

### DIFF
--- a/src/services/words.ts
+++ b/src/services/words.ts
@@ -33,7 +33,12 @@ const getByLanguageAndUser = async function(languageId: string, userId: number):
 const getUserwordsInText = async function(userId: number, textId: number, targetLanguageId: string, simple: boolean = true): Promise<Array<UserWord>> {
   const wordsResult: QueryResult = await wordData.getUserwordsInText(userId, textId, targetLanguageId, simple);
 
-  return wordsResult.rows;
+  return wordsResult.rows.map((row) => {
+    const modifiedRow = row;
+    modifiedRow.id = row.word_id;
+    delete modifiedRow.word_id;
+    return modifiedRow;
+  });
 };
 
 


### PR DESCRIPTION
## Description

* Service `getUserwordsInText` returns property `id` instead of `word_id`. 

## Related Issue

Closes #82 

## Acceptance Criteria

<!-- Include AC from the Github issue -->

## Type of Changes


|     | Type                       |
| --- | -------------------------- |
| ✓   | :bug: Bug fix              |
|     | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |
