### PR TITLE
Mh return new userword

### DIFF
--- a/src/data-access/words.ts
+++ b/src/data-access/words.ts
@@ -107,8 +107,9 @@ const getUserwordsInText = async function(userId: number, textId: number, target
   const USER_WORDS_IN_TEXT: string = `
       SELECT DISTINCT w.id AS word_id, 
                       w.word, 
-                      array_agg(t.translation) AS translations, 
-                      array_agg(ut.context) AS contexts, 
+                      array_agg(t.id) AS translation_ids,
+                      array_agg(t.translation) AS translation_texts,
+                      array_agg(ut.context) AS translation_contexts, 
                       uw.word_status AS status
         FROM words AS w 
         JOIN translations AS t ON w.id = t.word_id 

--- a/src/services/words.ts
+++ b/src/services/words.ts
@@ -33,12 +33,22 @@ const getByLanguageAndUser = async function(languageId: string, userId: number):
 const getUserwordsInText = async function(userId: number, textId: number, targetLanguageId: string, simple: boolean = true): Promise<Array<UserWord>> {
   const wordsResult: QueryResult = await wordData.getUserwordsInText(userId, textId, targetLanguageId, simple);
 
-  return wordsResult.rows.map((row) => {
-    const modifiedRow = row;
-    modifiedRow.id = row.word_id;
-    delete modifiedRow.word_id;
-    return modifiedRow;
-  });
+  const rawUserWords = wordsResult.rows;
+
+  const userWords = rawUserWords.map((rawWord) => ({
+    id: rawWord.word_id,
+    word: rawWord.word,
+    status: rawWord.word_status,
+    translations: rawWord.translation_ids.map((id: number, index: number) => ({
+      id,
+      wordId: rawWord.word_id,
+      targetLanguageId,
+      translation: rawWord.translation_texts[index],
+      context: rawWord.translation_contexts[index],
+    })),
+  }));
+
+  return userWords;
 };
 
 

--- a/src/services/words.ts
+++ b/src/services/words.ts
@@ -33,7 +33,12 @@ const getByLanguageAndUser = async function(languageId: string, userId: number):
 const getUserwordsInText = async function(userId: number, textId: number, targetLanguageId: string, simple: boolean = true): Promise<Array<UserWord>> {
   const wordsResult: QueryResult = await wordData.getUserwordsInText(userId, textId, targetLanguageId, simple);
 
-  return wordsResult.rows;
+  return wordsResult.rows.map((row) => {
+    const modifiedRow = row;
+    modifiedRow.id = row.word_id;
+    delete modifiedRow.word_id;
+    return modifiedRow;
+  });
 };
 
 


### PR DESCRIPTION
## Description

The user words in a text are now returned as the proper `UserWord` type with a nested array of nested translation objects instead of separate translation and context arrays-

## Related Issue

Closes #83 

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
|     | :sparkles: New feature     |
| :heavy_check_mark:     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

