### PR TITLE
service addNewUserWord adds word, translation and connections

### DIFF
--- a/src/data-access/translations.ts
+++ b/src/data-access/translations.ts
@@ -52,9 +52,10 @@ const add = async function(
 const addToUsersTranslations = async function(
   userId: number,
   translationId: number,
+  context: string | undefined,
 ) {
-  const USER_TRANSLATION = 'INSERT INTO users_translations (user_id, translation_id) VALUES(%L, %L) RETURNING users_translations.*';
-  const result = await dbQuery(USER_TRANSLATION, userId, translationId);
+  const USER_TRANSLATION = 'INSERT INTO users_translations (user_id, translation_id, context) VALUES(%L, %L, %L) RETURNING users_translations.*';
+  const result = await dbQuery(USER_TRANSLATION, userId, translationId, context);
   return result;
 };
 

--- a/src/routes/words.ts
+++ b/src/routes/words.ts
@@ -42,15 +42,11 @@ router.get('/text/:textId/language/:langId', async(req, res): Promise<void> => {
 
 router.post('/', async(req, res): Promise<void> => {
   const { user } = res.locals;
+  const userWordData: UserWord = req.body;
 
-  const wordData: Word = req.body;
-  const newWord: Word | null = await words.addNew(wordData);
+  const newUserWord = await words.addNewUserWord(user, userWordData);
 
-  if (newWord.id) {
-    const newStatus = await words.addStatus(newWord.id, user.id, 'learning');
-
-    res.status(201).json({ ...newWord, status: newStatus });
-  }
+  res.status(201).json(newUserWord);
 });
 
 

--- a/src/services/translations.ts
+++ b/src/services/translations.ts
@@ -42,14 +42,15 @@ const add = async function(
 ) {
   const result = await translationsData.add(wordId, translation, targetLang);
   if (!result.rows) throw boom.notFound('Adding new translation not successful.');
-  return result.rows.map((dbItem: TranslationDB) => convertTranslationTypes(dbItem));
+  return result.rows.map((dbItem: TranslationDB) => convertTranslationTypes(dbItem))[0];
 };
 
 const addToUsersTranslations = async function(
   userId: number,
   translationId: number,
+  context: string | undefined,
 ) {
-  const result = await translationsData.addToUsersTranslations(userId, translationId);
+  const result = await translationsData.addToUsersTranslations(userId, translationId, context);
   if (!result.rows) throw boom.notFound('Adding new translation with given user and translation id input not successful.');
   return result;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -174,7 +174,7 @@ export const convertTranslationTypes = function(dbItem: TranslationDB): Translat
   };
 };
 
-export type UserTranslation = Translation & { context: string };
+export type UserTranslation = Translation & { context?: string };
 
 
 // export type Context = {
@@ -199,7 +199,7 @@ export type UserTranslation = Translation & { context: string };
 
 
 export type UserWord = {
-  id: number,
+  id?: number,
   word: string,
   status: string,
   translations: Array<UserTranslation>,


### PR DESCRIPTION
## Description

The `POST api/words/`route now calls the new `addNewUserWord` service that takes a userword from the client and the user object `res.locals` and does these things:

- adds new word to `words` table or find existing word,
- adds that word's id to the userword object,
- adds user id word id  and status to `users_words` table,
- adds the provided translation to `translations` table,
- adds new translation's id to userword object's translation object
- adds user id and translation id and context to `users_translations` table
- returns the updated userword. 

I also had to make changes to translation services and data-access functions to make it work.

## Related Issue

Closes #79 
Closes #76 

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
|  :heavy_check_mark:   | :sparkles: New feature     |
|  :heavy_check_mark:   | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Testing Steps / QA Criteria

Please test it and tell me this works ;) 