### PR TITLE
check for existing status before adding new

### DIFF
--- a/src/data-access/words.ts
+++ b/src/data-access/words.ts
@@ -210,14 +210,17 @@ const getStatus = async function(wordId: number, userId: number): Promise<QueryR
     wordId,
   );
 
-  // if (result.rowCount === 0) return null;
-
-  // return result.rows[0].word_status;
   return result;
 };
 
 
 const addStatus = async function(wordId: number, userId: number, wordStatus: string): Promise<QueryResult> {
+  const existingStatus = await getStatus(wordId, userId);
+
+  if (existingStatus.rowCount > 0) {
+    return existingStatus;
+  }
+
   const ADD_USER_WORD_STATUS: string = `
     INSERT INTO users_words (user_id, word_id, word_status)
          VALUES (%s, %s, %L)
@@ -230,9 +233,6 @@ const addStatus = async function(wordId: number, userId: number, wordStatus: str
     wordStatus,
   );
 
-  // if (result.rowCount === 0) return null;
-
-  // return result.rows[0].word_status;
   return result;
 };
 
@@ -252,9 +252,6 @@ const updateStatus = async function(wordId: number, userId: number, wordStatus: 
     wordId,
   );
 
-  // if (result.rowCount === 0) return null;
-
-  // return result.rows[0].word_status;
   return result;
 };
 


### PR DESCRIPTION
## Description

If a combination of `userId` and `wordId` already exists in `users_words` no new connection is made and instead the saved status is returned. 

## Related Issue

Closes #93 

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
|  ✔️   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |


## Testing Steps / QA Criteria

Front end should use returned status as actual userword status. 
