### PR TITLE
mh backend features

### DIFF
--- a/src/data-access/words.ts
+++ b/src/data-access/words.ts
@@ -64,7 +64,8 @@ const getUserwordsByLanguage = async function(languageId: string, userId: number
              ut.user_id = %s 
              AND
              w.language_id = %L 
-    GROUP BY w.id, w.word, uw.word_status`;
+    GROUP BY w.id, w.word, uw.word_status
+    ORDER BY w.word ASC`;
 
   const result = await dbQuery(
     WORDS_BY_LANGUAGE_AND_USER,
@@ -129,6 +130,7 @@ const getUserwordsInText = async function(userId: number, textId: number, target
              w.tsquery_${tsvectorType} @@ (SELECT t.tsvector_${tsvectorType} FROM texts AS t 
                                             WHERE t.id = %s)        
     GROUP BY w.id, w.word, uw.word_status`;
+
 
   const result = await dbQuery(
     USER_WORDS_IN_TEXT,


### PR DESCRIPTION
## Description

`data-access` function `getUserwordsByLanguage` (used for the words page table) does two new things:
* the returned userwords are already sorted alphabetically
* the context string is returned with inline markup, surrounding all occurrences of the word in question with `<strong></strong>`

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
| :heavy_check_mark:     | :sparkles: New feature     |

