### PR TITLE
added removeUserWord functions

### DIFF
--- a/src/data-access/words.ts
+++ b/src/data-access/words.ts
@@ -245,6 +245,7 @@ const addStatus = async function(wordId: number, userId: number, wordStatus: str
   return result;
 };
 
+
 const updateStatus = async function(wordId: number, userId: number, wordStatus: string): Promise<QueryResult> {
   const UPDATE_USER_WORD_STATUS: string = `
        UPDATE users_words 
@@ -257,6 +258,23 @@ const updateStatus = async function(wordId: number, userId: number, wordStatus: 
   const result = await dbQuery(
     UPDATE_USER_WORD_STATUS,
     wordStatus,
+    userId,
+    wordId,
+  );
+
+  return result;
+};
+
+
+const removeUserWord = async function(wordId: number, userId: number): Promise<QueryResult> {
+  const REMOVE_USER_WORD: string = `
+    DELETE FROM users_words 
+          WHERE user_id = %s 
+            AND word_id = %S
+    RETURNING *`;
+
+  const result = await dbQuery(
+    REMOVE_USER_WORD,
     userId,
     wordId,
   );
@@ -278,4 +296,5 @@ export default {
   getStatus,
   addStatus,
   updateStatus,
+  removeUserWord,
 };

--- a/src/data-access/words.ts
+++ b/src/data-access/words.ts
@@ -270,7 +270,7 @@ const removeUserWord = async function(wordId: number, userId: number): Promise<Q
   const REMOVE_USER_WORD: string = `
     DELETE FROM users_words 
           WHERE user_id = %s 
-            AND word_id = %S
+            AND word_id = %s
     RETURNING *`;
 
   const result = await dbQuery(

--- a/src/routes/words.ts
+++ b/src/routes/words.ts
@@ -52,12 +52,16 @@ router.post('/', async(req, res): Promise<void> => {
 
 router.put('/:wordId', async(req, res): Promise<void> => {
   const { user } = res.locals;
-
-  const { status } = req.body;
   const { wordId } = req.params;
-  const updatedStatus: string | null = await words.updateStatus(Number(wordId), Number(user.id), status);
+  const { status } = req.body;
 
-  res.send(updatedStatus);
+  if (status) {
+    const updatedStatus: string = await words.updateStatus(Number(wordId), Number(user.id), status);
+    res.send(updatedStatus);
+  } else {
+    await words.removeUserWord(Number(wordId), Number(user.id));
+    res.status(204).send();
+  }
 });
 
 router.delete('/:wordId', async(req, res): Promise<void> => {

--- a/src/services/words.ts
+++ b/src/services/words.ts
@@ -129,6 +129,15 @@ const updateStatus = async function(wordId: number, userId: number, wordStatus: 
 };
 
 
+const removeUserWord = async function(wordId: number, userId: number): Promise<string> {
+  const result: QueryResult = await wordData.removeUserWord(wordId, userId);
+
+  if (result.rowCount === 0) throw boom.badRequest('Could not remove status.');
+
+  return result.rows[0].word_status;
+};
+
+
 const addNewUserWord = async function(user: SanitizedUser, userWordData: UserWord): Promise<UserWord> {
   const returnUserWord = userWordData;
 
@@ -173,5 +182,6 @@ export default {
   getStatus,
   addStatus,
   updateStatus,
+  removeUserWord,
   addNewUserWord,
 };


### PR DESCRIPTION
## Description

Ignoring a word on the front end should actually mean deleting the connection between user and word in the `users_words` table. This PR adds the required functionality.

## Related Issue

Closes #118 
(when corresponding front end PR gets merged)

|     | Type                       |
| --- | -------------------------- |
| :heavy_check_mark:     | :bug: Bug fix              |
| :heavy_check_mark:     | :sparkles: New feature     |

## Testing Steps / QA Criteria

Needs to be tested with corresponding front end update.
