### PR TITLE
Update readme for instructions on local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ Alexandria is accessible [here](https://tryalexandria.com/).
 
 # Running Alexandria locally for development
 
-First clone both this repo and the [frontend](https://github.com/alexandria-reader/frontend).
-Run `npm install` to install the dependencies, then add a .`env` file to the root directory with the values from `src/model/.env.sample`.
-Then run `npm run start-docker-postgres`, and add the seed data from `src/model/seed.sql`. Finally, run `npm run dev`.
-
-Now that the backend is started, follow the getting started instructions in the frontend `README.md`.
+1. Follow the instructions here [https://docs.docker.com/get-docker/] to install Docker Desktop
+2. Clone this repo and the [frontend](https://github.com/alexandria-reader/frontend)
+3. Run `npm install` to install the dependencies
+4. Add a .`env` file to the root directory with the values from `src/model/.env.sample`
+5. Run `npm run start-docker-postgres`
+6. Run `npm run dev`
+7. Follow the getting started instructions in the frontend `README.md`
 
 # Testing
 

--- a/postgres.yaml
+++ b/postgres.yaml
@@ -12,4 +12,6 @@ services:
     ports:
       - 8080:5432
     volumes:
-      - ./src/model/schema.sql:/docker-entrypoint-initdb.d/schema.sql
+      - "./src/model/schema.sql:/docker-entrypoint-initdb.d/schema.sql"
+      - "./src/model/seed.sql:/docker-entrypoint-initdb.d/seed.sql"
+      


### PR DESCRIPTION
## Description

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? -->

1. Updated the readme file for instructions to set up alexandria locally 
2. Added seed.sql to be copied when initialising docker container- as part of the previous instructions it says to add seed data when we can do this automatically by adding this to the yaml file. 

(Apologise if there's a good reason why this isn't included in the yaml file, but as it's locally run it made sense to me to include this so that seed.sql gets run automatically on docker container initialisation).

Numbers/bullet points are easier to follow visually than a paragraph of instructions. Made some of the instructions a bit plainer than previous.

## Related Issue

N/A

## Acceptance Criteria

N/A

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
|     | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies 
| ✓ | :scroll: Docs              |

## Updates

### Before

No UI updates

### After

No UI updates

## Testing Steps / QA Criteria

Follow the updated instructions outlined in the readme to reproduce steps.

