### PR TITLE
chore: remove dotenv type dependency package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
       "devDependencies": {
         "@types/bcrypt": "^5.0.0",
         "@types/cors": "^2.8.12",
-        "@types/dotenv": "^8.2.0",
         "@types/express": "^4.17.14",
         "@types/jest": "^29.2.0",
         "@types/jsonwebtoken": "^8.5.9",
@@ -1391,16 +1390,6 @@
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
       "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
       "dev": true
-    },
-    "node_modules/@types/dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-ylSC9GhfRH7m1EUXBXofhgx4lUWmFeQDINW5oLuS+gxWdfUeW4zJdeVTYVkexEW+e2VUvlZR2kGnGGipAWR7kw==",
-      "deprecated": "This is a stub types definition. dotenv provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "dotenv": "*"
-      }
     },
     "node_modules/@types/express": {
       "version": "4.17.14",
@@ -9236,15 +9225,6 @@
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
       "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
       "dev": true
-    },
-    "@types/dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-ylSC9GhfRH7m1EUXBXofhgx4lUWmFeQDINW5oLuS+gxWdfUeW4zJdeVTYVkexEW+e2VUvlZR2kGnGGipAWR7kw==",
-      "dev": true,
-      "requires": {
-        "dotenv": "*"
-      }
     },
     "@types/express": {
       "version": "4.17.14",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   "devDependencies": {
     "@types/bcrypt": "^5.0.0",
     "@types/cors": "^2.8.12",
-    "@types/dotenv": "^8.2.0",
     "@types/express": "^4.17.14",
     "@types/jest": "^29.2.0",
     "@types/jsonwebtoken": "^8.5.9",


### PR DESCRIPTION
## Description

Previously you needed the specific type dependency for dotenv, this isn't required. This change removes the need to install the dotenv type dependency package.

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
|     | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
| ✓ | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

@types/dot-env package was part of the dev dependencies

### After

@types/dot-env package has been uninstalled.

