### PR TITLE
Fix Resend from address to match verified domain

### DIFF
--- a/backend/src/utils/sendmail.ts
+++ b/backend/src/utils/sendmail.ts
@@ -20,7 +20,7 @@ const sendVerificationEmail = async function (
 
   try {
     const { error } = await getResendClient().emails.send({
-      from: 'Alexandria <noreply@tryalexandria.com>',
+      from: 'Alexandria <noreply@signup.tryalexandria.com>',
       to: email,
       subject: 'Verify your email address for Alexandria',
       text: `Text version of the link: ${verifyUrl}`,


### PR DESCRIPTION
## Summary
- Updated email from address from `noreply@tryalexandria.com` to `noreply@signup.tryalexandria.com`
- The verified Resend domain is `signup.tryalexandria.com` — emails from the root domain were rejected with 403 `validation_error`

## Test plan
- [ ] Merge and deploy
- [ ] Sign up with a test account and verify the verification email is sent successfully
- [ ] Check backend logs for absence of Resend 403 errors